### PR TITLE
store cookies

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -48,9 +48,14 @@ async function post(url, options = {}, cf = false) {
     return await request(url, options, cf);
 }
 
+async function jar() { 
+    return await rp.jar() 
+}
+
 module.exports = {
     get,
     post,
     delay,
-    timeout
+    timeout, 
+    jar
 }


### PR DESCRIPTION
This is a draft PR of my attempt at storing the hcaptcha cookies. At the moment, the cookies are saved to the temp dir, but for whatever reason, `request.jar` doesn't seem to exist (despite it working fine in the node console). Js really makes me wanna kill myself.

Also, no idea why it has detected the whole file as a change, but whatever. 